### PR TITLE
Fix RemovedInDjango20Warning in models.py

### DIFF
--- a/missing/models.py
+++ b/missing/models.py
@@ -1,5 +1,11 @@
 from django.conf import settings
-from django.core import urlresolvers
+
+try:
+    # RemovedInDjango20Warning: Importing from django.core.urlresolvers
+    # is deprecated in favor of django.urls
+    from django.urls import urlresolvers
+except ImportError:
+    from django.core import urlresolvers
 
 # To load docutils extensions somewhere
 from missing import admindocs


### PR DESCRIPTION
Use python's 'better to ask for forgiveness than permission'
mantra and attempt to import the new location first, falling
back to the legacy location on ImportError.

I tested with 'python -Wall setup.py test' before and after
the patch. I verified the deprecation warning appears before
the patch and does not once the patch is applied.

All tests pass.